### PR TITLE
Add dismissible Arthouse launch banner through end of week

### DIFF
--- a/app/ui/header.tsx
+++ b/app/ui/header.tsx
@@ -1,4 +1,5 @@
 import { Link } from "react-router";
+import LaunchBanner from "./launch-banner";
 
 // Utility Functions
 const getTimeUntilStream = (startTime: string) => {
@@ -75,17 +76,20 @@ const SocialLinks = () => {
 
 const TopBar = () => {
   return (
-    <div className="flex justify-between items-center w-full pb-4">
-      <div className="flex flex-row gap-2 items-center text-sm">
-        Made by{" "}
-        <a
-          href="https://chrcit.com/projects/hasanhub-com"
-          className="underline underline-offset-2 font-semibold"
-        >
-          chrcit
-        </a>
+    <div className="flex flex-col w-full pb-4 gap-0">
+      <div className="flex justify-between items-center w-full">
+        <div className="flex flex-row gap-2 items-center text-sm">
+          Made by{" "}
+          <a
+            href="https://chrcit.com/projects/hasanhub-com"
+            className="underline underline-offset-2 font-semibold"
+          >
+            chrcit
+          </a>
+        </div>
+        <SocialLinks />
       </div>
-      <SocialLinks />
+      <LaunchBanner />
     </div>
   );
 };

--- a/app/ui/launch-banner.tsx
+++ b/app/ui/launch-banner.tsx
@@ -1,8 +1,8 @@
 import { useEffect, useState } from "react";
 
-const STORAGE_KEY = "hasanhub:launch-banner-dismissed-2026-08";
+const STORAGE_KEY = "hasanhub:launch-banner-dismissed-2026-09";
 const DISMISS_EVENT = "hasanhub:launch-banner-dismiss";
-const BANNER_EXPIRES_AT = Date.parse("2026-08-17T00:00:00.000Z"); // end of week (Sun Aug 16)
+const BANNER_EXPIRES_AT = Date.parse("2026-09-24T00:00:00.000Z"); // through Sept 23
 const ARTHOUSE_BLUE = "#0011ff";
 
 const SOCIAL_LINKS = [

--- a/app/ui/launch-banner.tsx
+++ b/app/ui/launch-banner.tsx
@@ -1,0 +1,98 @@
+import { useEffect, useState } from "react";
+
+const STORAGE_KEY = "hasanhub:launch-banner-dismissed-2026-08";
+const DISMISS_EVENT = "hasanhub:launch-banner-dismiss";
+const BANNER_EXPIRES_AT = Date.parse("2026-08-17T00:00:00.000Z"); // end of week (Sun Aug 16)
+const ARTHOUSE_BLUE = "#0011ff";
+
+const SOCIAL_LINKS = [
+  {
+    label: "IG",
+    href: "https://www.instagram.com/reel/Db8c6OvooJJ/",
+  },
+  {
+    label: "Twitter",
+    href: "https://x.com/madebyarthouse/status/2087560065767084386",
+  },
+  {
+    label: "Bluesky",
+    href: "https://bsky.app/profile/chrcit.bsky.social/post/3msvmi23c222x",
+  },
+] as const;
+
+const isDismissed = () => {
+  try {
+    return window.localStorage.getItem(STORAGE_KEY) === "1";
+  } catch {
+    return false;
+  }
+};
+
+const shouldShowBanner = () =>
+  Date.now() < BANNER_EXPIRES_AT && !isDismissed();
+
+const LaunchBanner = () => {
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    setVisible(shouldShowBanner());
+
+    const hide = () => setVisible(false);
+    window.addEventListener(DISMISS_EVENT, hide);
+    window.addEventListener("storage", hide);
+
+    return () => {
+      window.removeEventListener(DISMISS_EVENT, hide);
+      window.removeEventListener("storage", hide);
+    };
+  }, []);
+
+  if (!visible) return null;
+
+  const dismiss = () => {
+    try {
+      window.localStorage.setItem(STORAGE_KEY, "1");
+    } catch {
+      // Ignore storage failures; banner still closes for this session.
+    }
+    window.dispatchEvent(new Event(DISMISS_EVENT));
+    setVisible(false);
+  };
+
+  return (
+    <div
+      className="relative mt-2 w-full pr-8 text-sm font-black leading-snug text-white sm:text-base"
+      style={{ backgroundColor: ARTHOUSE_BLUE }}
+      role="region"
+      aria-label="Launch announcement"
+    >
+      <p className="px-3 py-2.5">
+        I&apos;m starting something new, if you&apos;ve used Hasanhub over the
+        years pls watch and like my launch post on{" "}
+        {SOCIAL_LINKS.map((link, index) => (
+          <span key={link.href}>
+            {index > 0 ? " or " : null}
+            <a
+              href={link.href}
+              target="_blank"
+              rel="noreferrer"
+              className="underline underline-offset-2 hover:opacity-90"
+            >
+              {link.label}
+            </a>
+          </span>
+        ))}
+      </p>
+      <button
+        type="button"
+        onClick={dismiss}
+        aria-label="Dismiss launch banner"
+        className="absolute right-1.5 top-1.5 flex h-6 w-6 items-center justify-center text-lg font-black leading-none text-white hover:opacity-80"
+      >
+        ×
+      </button>
+    </div>
+  );
+};
+
+export default LaunchBanner;

--- a/app/ui/sidebar.tsx
+++ b/app/ui/sidebar.tsx
@@ -4,6 +4,7 @@ import useActionUrl from "~/hooks/use-action-url";
 import useUrlState from "~/hooks/use-url-state";
 import type { TagSidebarRecord } from "../../db/types";
 import { Logo, StreamInfoComponent } from "./header";
+import LaunchBanner from "./launch-banner";
 import clsx from "clsx";
 
 // Component-specific types that match the transformed data from root.tsx
@@ -63,14 +64,17 @@ const MobileHeader = ({
         <div className="hidden sm:block">
           <SidebarSocialLinks />
         </div>
-        <div className="font-semibold">
-          Made by{" "}
-          <a
-            href="https://chrcit.com/projects/hasanhub-com"
-            className="underline underline-offset-2 font-semibold"
-          >
-            chrcit
-          </a>
+        <div className="w-full sm:w-auto">
+          <div className="font-semibold">
+            Made by{" "}
+            <a
+              href="https://chrcit.com/projects/hasanhub-com"
+              className="underline underline-offset-2 font-semibold"
+            >
+              chrcit
+            </a>
+          </div>
+          <LaunchBanner />
         </div>
       </div>
     </header>
@@ -169,6 +173,7 @@ const SidebarFooter = () => {
           </div>
           <SidebarSocialLinks />
         </div>
+        <LaunchBanner />
       </div>
     </div>
   );


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Adds a one-time launch banner under the “Made by chrcit” credit (mobile header + desktop sidebar footer).
- Arthouse blue (`#0011ff`) background, white bold text, dismiss × in the top-right.
- Links IG / Twitter / Bluesky to the launch posts.
- Auto-hides after September 23 (`2026-09-24T00:00:00Z`) and after dismiss (localStorage).

## Test plan
- [ ] Open site before Sept 23 → banner appears under Made by chrcit
- [ ] Tap IG / Twitter / Bluesky links → correct posts open
- [ ] Dismiss with × → stays gone on reload
- [ ] After Sept 23 → banner does not show even if not dismissed
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019ff793-69b3-71f2-991d-e9223247fdd2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019ff793-69b3-71f2-991d-e9223247fdd2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

