### PR TITLE
Parallelize Twitch and D1 in video route loaders

### DIFF
--- a/app/lib/get-stream-info.server.ts
+++ b/app/lib/get-stream-info.server.ts
@@ -93,10 +93,26 @@ const fetchTwitchJson = async <T>(
   return (await response.json()) as T;
 };
 
+const isUnauthorizedError = (error: unknown): error is StreamInfoError =>
+  Boolean(
+    error &&
+      typeof error === "object" &&
+      (error as StreamInfoError).unauthorized
+  );
+
+const valueOrNull = <T>(result: PromiseSettledResult<T>): T | null => {
+  if (result.status === "fulfilled") {
+    return result.value;
+  }
+
+  console.warn("Twitch API call failed:", result.reason);
+  return null;
+};
+
 const getStreamInfoFromToken = async (accessToken: string) => {
   const clientId = env.TWITCH_CLIENT_ID?.trim() ?? "";
 
-  return await Promise.all([
+  const [infoResult, scheduleResult] = await Promise.allSettled([
     fetchTwitchJson<StreamInfo>(
       "https://api.twitch.tv/helix/streams?first=1&user_id=207813352",
       accessToken,
@@ -108,6 +124,16 @@ const getStreamInfoFromToken = async (accessToken: string) => {
       clientId
     ),
   ]);
+
+  const unauthorizedResult = [infoResult, scheduleResult].find(
+    (result): result is PromiseRejectedResult =>
+      result.status === "rejected" && isUnauthorizedError(result.reason)
+  );
+  if (unauthorizedResult) {
+    throw unauthorizedResult.reason;
+  }
+
+  return [valueOrNull(infoResult), valueOrNull(scheduleResult)] as const;
 };
 
 export const getStreamInfo = async () => {
@@ -116,11 +142,7 @@ export const getStreamInfo = async () => {
   try {
     return await getStreamInfoFromToken(accessToken);
   } catch (error) {
-    if (
-      error &&
-      typeof error === "object" &&
-      (error as StreamInfoError).unauthorized
-    ) {
+    if (isUnauthorizedError(error)) {
       const refreshedToken = await getValidAccessToken({ forceRefresh: true });
       return getStreamInfoFromToken(refreshedToken);
     }

--- a/app/lib/get-videos.ts
+++ b/app/lib/get-videos.ts
@@ -123,25 +123,35 @@ const getVideos = async (
         ? desc(Video.views)
         : desc(Video.publishedAt);
 
-  const videos = await db
-    .select({
-      id: Video.id,
-      youtubeId: Video.youtubeId,
-      largeThumbnailUrl: Video.largeThumbnailUrl,
-      title: Video.title,
-      publishedAt: Video.publishedAt,
-      views: Video.views,
-      duration: Video.duration,
-      channelId: Video.channelId,
-      channelTitle: Channel.title,
-      channelSmallThumbnailUrl: Channel.smallThumbnailUrl,
-      channelYoutubeId: Channel.youtubeId,
-    })
-    .from(Video)
-    .leftJoin(Channel, eq(Video.channelId, Channel.id))
-    .where(and(...pageConditions))
-    .orderBy(ordering)
-    .limit(take ?? 25);
+  const shouldCount = !(options.skipCount || lastVideoId);
+  const [videos, totalVideosCount] = await Promise.all([
+    db
+      .select({
+        id: Video.id,
+        youtubeId: Video.youtubeId,
+        largeThumbnailUrl: Video.largeThumbnailUrl,
+        title: Video.title,
+        publishedAt: Video.publishedAt,
+        views: Video.views,
+        duration: Video.duration,
+        channelId: Video.channelId,
+        channelTitle: Channel.title,
+        channelSmallThumbnailUrl: Channel.smallThumbnailUrl,
+        channelYoutubeId: Channel.youtubeId,
+      })
+      .from(Video)
+      .leftJoin(Channel, eq(Video.channelId, Channel.id))
+      .where(and(...pageConditions))
+      .orderBy(ordering)
+      .limit(take ?? 25),
+    shouldCount
+      ? db
+          .select({ count: sql<number>`count(*)` })
+          .from(Video)
+          .where(and(...filterConditions))
+          .then((countRow) => Number(countRow[0]?.count ?? 0))
+      : Promise.resolve(0),
+  ]);
 
   const videoIds = videos.map((video) => video.id).filter(Boolean);
   const tags = videoIds.length
@@ -196,17 +206,6 @@ const getVideos = async (
           : null,
       })) ?? [],
   }));
-
-  if (options.skipCount || lastVideoId) {
-    return [data, 0] as const;
-  }
-
-  const countRow = await db
-    .select({ count: sql<number>`count(*)` })
-    .from(Video)
-    .where(and(...filterConditions));
-
-  const totalVideosCount = Number(countRow[0]?.count ?? 0);
 
   return [data, totalVideosCount] as const;
 };

--- a/app/routes/__videos.tsx
+++ b/app/routes/__videos.tsx
@@ -40,6 +40,40 @@ export type VideosLayoutContext = {
   streamSchedule?: StreamScheduleDisplay;
 };
 
+const emptyStreamDisplay: {
+  streamInfo: StreamInfoDisplay | null;
+  streamSchedule: StreamScheduleDisplay | null;
+} = {
+  streamInfo: null,
+  streamSchedule: null,
+};
+
+const loadStreamDisplay = async () => {
+  try {
+    const [info, schedule] = await getStreamInfo();
+    return {
+      streamInfo: info?.data?.length
+        ? {
+            user_login: info.data[0].user_login,
+            user_name: info.data[0].user_name,
+            title: info.data[0].title,
+          }
+        : null,
+      streamSchedule: schedule?.data?.segments?.length
+        ? {
+            broadcaster_login: schedule.data.broadcaster_login,
+            broadcaster_name: schedule.data.broadcaster_name,
+            start_time: schedule.data.segments[0].start_time,
+            title: schedule.data.segments[0].title,
+          }
+        : null,
+    };
+  } catch (error) {
+    console.warn("Stream info unavailable:", error);
+    return emptyStreamDisplay;
+  }
+};
+
 export const loader = async ({ request }: Route.LoaderArgs) => {
   const url = new URL(request.url);
   const slugs = url.pathname.startsWith("/tags/")
@@ -50,50 +84,13 @@ export const loader = async ({ request }: Route.LoaderArgs) => {
     throw new Response("Not found", { status: 404, statusText: "Not found" });
   }
 
-  const tags = await getTagsForSidebar(db);
   const tagSlugs = TagSlugsValidator.parse(slugs) ?? [];
-
-  let streamInfo: StreamInfoDisplay | null = null;
-  let streamSchedule: StreamScheduleDisplay | null = null;
-
-  if (isCrawlerRequest(request)) {
-    return new Response(
-      JSON.stringify({
-        tags,
-        tagSlugs,
-        streamInfo,
-        streamSchedule,
-      }),
-      {
-        status: 200,
-        headers: {
-          "Content-Type": "application/json",
-          "Cache-Control": cacheHeader(TAGS_SIDEBAR_CACHE_POLICY),
-        },
-      }
-    );
-  }
-
-  try {
-    const [info, schedule] = await getStreamInfo();
-    streamInfo = info?.data?.length
-      ? {
-          user_login: info.data[0].user_login,
-          user_name: info.data[0].user_name,
-          title: info.data[0].title,
-        }
-      : null;
-    streamSchedule = schedule?.data?.segments?.length
-      ? {
-          broadcaster_login: schedule.data.broadcaster_login,
-          broadcaster_name: schedule.data.broadcaster_name,
-          start_time: schedule.data.segments[0].start_time,
-          title: schedule.data.segments[0].title,
-        }
-      : null;
-  } catch (error) {
-    console.warn("Stream info unavailable:", error);
-  }
+  // Single fetch runs this layout loader in the same Worker request as the
+  // leaf route. Start Twitch and sidebar D1 together so they overlap with it.
+  const [tags, { streamInfo, streamSchedule }] = await Promise.all([
+    getTagsForSidebar(db),
+    isCrawlerRequest(request) ? emptyStreamDisplay : loadStreamDisplay(),
+  ]);
 
   return new Response(
     JSON.stringify({

--- a/app/routes/__videos.tsx
+++ b/app/routes/__videos.tsx
@@ -49,29 +49,24 @@ const emptyStreamDisplay: {
 };
 
 const loadStreamDisplay = async () => {
-  try {
-    const [info, schedule] = await getStreamInfo();
-    return {
-      streamInfo: info?.data?.length
-        ? {
-            user_login: info.data[0].user_login,
-            user_name: info.data[0].user_name,
-            title: info.data[0].title,
-          }
-        : null,
-      streamSchedule: schedule?.data?.segments?.length
-        ? {
-            broadcaster_login: schedule.data.broadcaster_login,
-            broadcaster_name: schedule.data.broadcaster_name,
-            start_time: schedule.data.segments[0].start_time,
-            title: schedule.data.segments[0].title,
-          }
-        : null,
-    };
-  } catch (error) {
-    console.warn("Stream info unavailable:", error);
-    return emptyStreamDisplay;
-  }
+  const [info, schedule] = await getStreamInfo();
+  return {
+    streamInfo: info?.data?.length
+      ? {
+          user_login: info.data[0].user_login,
+          user_name: info.data[0].user_name,
+          title: info.data[0].title,
+        }
+      : null,
+    streamSchedule: schedule?.data?.segments?.length
+      ? {
+          broadcaster_login: schedule.data.broadcaster_login,
+          broadcaster_name: schedule.data.broadcaster_name,
+          start_time: schedule.data.segments[0].start_time,
+          title: schedule.data.segments[0].title,
+        }
+      : null,
+  };
 };
 
 export const loader = async ({ request }: Route.LoaderArgs) => {
@@ -87,10 +82,25 @@ export const loader = async ({ request }: Route.LoaderArgs) => {
   const tagSlugs = TagSlugsValidator.parse(slugs) ?? [];
   // Single fetch runs this layout loader in the same Worker request as the
   // leaf route. Start Twitch and sidebar D1 together so they overlap with it.
-  const [tags, { streamInfo, streamSchedule }] = await Promise.all([
+  // allSettled keeps a broken Twitch call from failing the layout (and videos).
+  const [tagsResult, streamResult] = await Promise.allSettled([
     getTagsForSidebar(db),
     isCrawlerRequest(request) ? emptyStreamDisplay : loadStreamDisplay(),
   ]);
+
+  if (tagsResult.status === "rejected") {
+    throw tagsResult.reason;
+  }
+
+  if (streamResult.status === "rejected") {
+    console.warn("Stream info unavailable:", streamResult.reason);
+  }
+
+  const tags = tagsResult.value;
+  const { streamInfo, streamSchedule } =
+    streamResult.status === "fulfilled"
+      ? streamResult.value
+      : emptyStreamDisplay;
 
   return new Response(
     JSON.stringify({


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Cloudflare traces for `GET /tags/cringe` (and the other video routes) show a waterfall inside a single Worker request:

1. Three concurrent D1 queries (~190ms): sidebar tags, active tag, videos page
2. Two more D1 queries (~180ms): video tags + Twitch token lookup
3. Then the two Helix `fetch` spans (~310ms), which do not start until all D1 has finished

That matches the layout loader awaiting `getTagsForSidebar()` before `getStreamInfo()`. React Router framework mode uses **single fetch**, so layout and leaf loaders share one request instead of two parallel HTTP requests. The server still starts both loaders together (`Promise.all` in RR's default data strategy), but any `await` inside the layout delays Twitch until that work finishes.

The same pattern shows up across routes. Last-day wall time (successful fetches):

| Path | avg | p95 |
|---|---|---|
| `/` | 640ms | 1121ms |
| `/_root.data` (client navigations) | 644ms | 1091ms |
| `/tags/*` | ~470–630ms avg | often 1.0–1.5s |

Homepage is a bit worse because `getVideos` also ran `COUNT(*)` only after the videos and per-video tags queries.

## Change

- **Videos layout** (`app/routes/__videos.tsx`): start sidebar D1 and Twitch with `Promise.allSettled`. A broken Helix call logs a warning and renders without stream info; it does not fail the layout (which would also fail the video grid). Crawlers still skip Twitch. Sidebar D1 failures still throw.
- **Twitch client** (`app/lib/get-stream-info.server.ts`): the live stream and schedule fetches also use `Promise.allSettled`, so one dead endpoint does not drop the other. 401s still trigger a token refresh.
- **Video list query** (`app/lib/get-videos.ts`): run the count query in parallel with the page query. Tag-by-video-id still waits on the page result.

Expected trace after deploy: Helix fetches start after the token D1 (~190ms), overlapping the remaining video-tag D1, instead of after every D1 query. Total time should land closer to `max(D1 waterfall, Twitch)` than `sum(D1 waterfall, Twitch)`.

## Test plan

- [ ] Load `/` and `/tags/cringe` and confirm sidebar tags, stream status, and video grid still render
- [ ] Confirm crawler/empty UA responses still omit Twitch calls
- [ ] In Cloudflare Observability traces, confirm Helix `fetch` spans overlap D1 instead of starting after the last `d1_all`
- [ ] Spot-check a filtered homepage URL (count still used) and a tag URL without filters (stored `videoCount`, count skipped)
- [ ] Confirm a Twitch 5xx / timeout still returns videos and tags, with stream info empty
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a0123a-9f75-75cd-8057-12216fca7f7d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a0123a-9f75-75cd-8057-12216fca7f7d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

